### PR TITLE
[fix] correct type for lastpresetidx and getter for rangeofnum settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # build artifacts
 build/
 obj-x86_64-linux-gnu/
+lib/vis_milkdrop/*.inc
 visualization.*/addon.xml
 
 # commonly used editors

--- a/src/MilkdropXBMC.cpp
+++ b/src/MilkdropXBMC.cpp
@@ -150,13 +150,13 @@ ADDON_STATUS CVisualizationMilkdrop::Create()
     g_plugin->PluginPreInitialize(0, 0);
   }
 
-  g_plugin->m_fBlendTimeAuto = kodi::GetSettingInt("Automatic Blend Time") + 1;
-  g_plugin->m_fTimeBetweenPresets = kodi::GetSettingInt("Time Between Presets") * 5 + 5;
-  g_plugin->m_fTimeBetweenPresetsRand = kodi::GetSettingInt("Additional Random Time") * 5 + 5;
+  g_plugin->m_fBlendTimeAuto = kodi::GetSettingFloat("Automatic Blend Time") + 1;
+  g_plugin->m_fTimeBetweenPresets = kodi::GetSettingFloat("Time Between Presets") * 5 + 5;
+  g_plugin->m_fTimeBetweenPresetsRand = kodi::GetSettingFloat("Additional Random Time") * 5 + 5;
   g_plugin->m_bHardCutsDisabled = !kodi::GetSettingBoolean("Enable Hard Cuts");
-  g_plugin->m_fHardCutLoudnessThresh = kodi::GetSettingInt("Loudness Threshold For Hard Cuts") / 5.0f + 1.25f;
-  g_plugin->m_fHardCutHalflife = kodi::GetSettingInt("Average Time Between Hard Cuts") * 5 + 5;
-  g_plugin->m_max_fps_fs = kodi::GetSettingInt("Maximum Refresh Rate") * 5 + 20;
+  g_plugin->m_fHardCutLoudnessThresh = kodi::GetSettingFloat("Loudness Threshold For Hard Cuts") / 5.0f + 1.25f;
+  g_plugin->m_fHardCutHalflife = kodi::GetSettingFloat("Average Time Between Hard Cuts") * 5 + 5;
+  g_plugin->m_max_fps_fs = kodi::GetSettingFloat("Maximum Refresh Rate") * 5 + 20;
   g_plugin->m_bAlways3D = kodi::GetSettingBoolean("Enable Stereo 3d");
   lastLockedStatus = kodi::GetSettingBoolean("lastlockedstatus");
   lastPresetIndx = kodi::GetSettingInt("lastpresetidx");

--- a/visualization.milkdrop/resources/settings.xml
+++ b/visualization.milkdrop/resources/settings.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <setting id="lastpresetfolder" type="text" default="" visible="false" />
-    <setting id="lastpresetidx" type="integer" default="0" visible="false" />
+    <setting id="lastpresetidx" type="number" default="0" visible="false" />
     <setting id="lastlockedstatus" type="bool" default="false" visible="false" />
     <setting id="Preset Pack" type="enum" label="30009" lvalues="30020|30021|30022" default="0"/>
     <setting id="User Preset Folder" type="folder" visible="eq(-1,2)" source="" label="30010" default=""/>


### PR DESCRIPTION
silences the following log lines

```
WARNING: CAddonSettings[visualization.milkdrop]: failed to parse old setting definition for "lastpresetidx" of type "integer"
  DEBUG: CSettingsManager: requested setting (lastpresetidx) was not found.
  DEBUG: CAddonSettings[visualization.milkdrop]: failed to find definition for setting lastpresetidx. Creating a setting on-the-fly...
```

```
ERROR: kodi::General::ADDON::CAddonDll::get_setting_int - setting 'Automatic Blend Time' is not a integer in 'MilkDrop'
ERROR: kodi::General::ADDON::CAddonDll::get_setting_int - setting 'Time Between Presets' is not a integer in 'MilkDrop'
ERROR: kodi::General::ADDON::CAddonDll::get_setting_int - setting 'Additional Random Time' is not a integer in 'MilkDrop'
ERROR: kodi::General::ADDON::CAddonDll::get_setting_int - setting 'Loudness Threshold For Hard Cuts' is not a integer in 'MilkDrop'
ERROR: kodi::General::ADDON::CAddonDll::get_setting_int - setting 'Average Time Between Hard Cuts' is not a integer in 'MilkDrop'
ERROR: kodi::General::ADDON::CAddonDll::get_setting_int - setting 'Maximum Refresh Rate' is not a integer in 'MilkDrop'
```